### PR TITLE
Fix: Throw error if MONGODB_URI is missing in configuration (#4)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,9 +14,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
     MongooseModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
-        uri:
-          configService.get<string>('MONGODB_URI') ||
-          'mongodb://localhost:27017/nestjs-todo',
+        uri: configService.get<string>('MONGODB_URI'),
       }),
       inject: [ConfigService],
     }),


### PR DESCRIPTION
## 📋 PR Description

This PR resolves issue #4 by ensuring that the MongoDB connection URL (MONGODB_URI) is fetched from the configuration. If the value is missing, the application will throw an error during startup, preventing the use of a default value.

Closes #4 